### PR TITLE
feat: catch transport errors

### DIFF
--- a/packages/core/src/createLogger.test.ts
+++ b/packages/core/src/createLogger.test.ts
@@ -84,4 +84,15 @@ describe("createLogger", () => {
       data: { foo: "bar" },
     });
   });
+
+  it("should catch errors thrown by transports", () => {
+    const transport = createTransport(() => {
+      throw new Error("oops");
+    });
+    const logger = createLogger({
+      transports: [transport],
+    });
+
+    expect(() => logger.info("hello")).not.toThrow();
+  });
 });

--- a/packages/core/src/createLogger.ts
+++ b/packages/core/src/createLogger.ts
@@ -38,7 +38,13 @@ export function createLogger(options: LoggerOptions) {
       data: Object.keys(combinedData).length > 0 ? combinedData : undefined,
     };
 
-    options.transports.forEach((transport) => transport.process(log));
+    options.transports.forEach((transport) => {
+      try {
+        transport.process(log);
+      } catch (error) {
+        console.warn("Failed to process log", error);
+      }
+    });
   }
 
   const logger: PlainLogger = {


### PR DESCRIPTION
I would argue that a logger should never throw errors, as you wouldn't want logging to hinder code execution.